### PR TITLE
Notify when video isn't playable on iOS

### DIFF
--- a/ios/Classes/NativeVideoPlayerViewController.swift
+++ b/ios/Classes/NativeVideoPlayerViewController.swift
@@ -48,6 +48,10 @@ extension NativeVideoPlayerViewController: NativeVideoPlayerApiDelegate {
             return
         }
         let videoAsset = isUrl ? AVURLAsset(url: uri, options: ["AVURLAssetHTTPHeaderFieldsKey": videoSource.headers]) : AVAsset(url: uri)
+        if !videoAsset.isPlayable {
+            api.onError(NSError(domain: "NativeVideoPlayer", code: -1, userInfo: [NSLocalizedDescriptionKey: "Video is not playable"]))
+            return
+        }
         let playerItem = AVPlayerItem(asset: videoAsset)
 
         removeOnVideoCompletedObserver()


### PR DESCRIPTION
Solves the issue on iOS described in #28 

When playing an unsupported video format (VP9 codec) on iOS, the video is blank with audio playing just fine and listeners to `onError` were't getting notified. 

Tested on iOS with an unsupported video (VP9 codec) and by passing a `VideoSource` `path` with no video file. In both cases, `onError` notifies listeners.